### PR TITLE
Ajout d'un système d'alerte en fonction du nombre d'édits

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Bienvenue sur le répertoire du Bot Discord présent sur le serveur Hyakanime.
 
 # Crédits 
 
-| Fonctionnalités  | Auteur                                   |
-| ---------------- | ---------------------------------------- |
-| Agenda           | [Dem0nx309](https://github.com/dem0nx309)|
-| Twitter          | [Dem0nx309](https://github.com/dem0nx309)|
-| User             | [Dem0nx309](https://github.com/dem0nx309)|
+| Fonctionnalités     | Auteur                                   |
+| ----------------    | ---------------------------------------- |
+| Avertissement Edits | [Dem0nx309](https://github.com/dem0nx309)|                                       
+| Agenda              | [Dem0nx309](https://github.com/dem0nx309)|
+| Twitter             | [Dem0nx309](https://github.com/dem0nx309)|
+| User                | [Dem0nx309](https://github.com/dem0nx309)|

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
 	"token": "REMPLIR-AVEC-LE-TOKEN-DU-BOT",
 	"applicationId" : "REMPLIR-AVEC-L-APPLICATION-ID-DU-BOT",
 	"channelBeta": "1036762035645599755",
-	"ChannelEdit":"954454349210337361",
+	"channelEdit":"954454349210337361",
 	"channelBienvenue": "846317312327811092",
 	"roleMembre" : "845340817828479026",
 	"rolePatchNotes" : "1012649092343668857",

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
 	"token": "REMPLIR-AVEC-LE-TOKEN-DU-BOT",
 	"applicationId" : "REMPLIR-AVEC-L-APPLICATION-ID-DU-BOT",
 	"channelBeta": "1036762035645599755",
+	"ChannelEdit":"954454349210337361",
 	"channelBienvenue": "846317312327811092",
 	"roleMembre" : "845340817828479026",
 	"rolePatchNotes" : "1012649092343668857",

--- a/index.js
+++ b/index.js
@@ -51,16 +51,14 @@ client.login(token);
 var alerte = 0; // 0 = Ok - 1 = Avertissement - 2 = Stop - 3 = Alerte
 
 cron.schedule("0 */6 * * *", async () => {
-
   let responseAdminStats = await fetch("https://api.hyakanime.fr/admin/stats");
   let dataAdminStats = await responseAdminStats.text();
   var resultatAdminStats = JSON.parse(dataAdminStats);
-
   const embedAvertissementEdit = new EmbedBuilder()
     .setAuthor({ name: "⚠️ Avertissement Edits" })
     .setColor("#ff6700")
     .setDescription(
-      `**Actuellement il y a ${resultatAdminStats.editAnime} edits en cours ! \n\n Merci de vous calmez sur les edits tant que l'alerte est présente.**` //25
+      `**Actuellement il y a ${resultatAdminStats.editAnime} édits en cours ! \n\n Merci de vous calmer sur les édits tant que l'alerte est présente.**` //25
     )
     .setTimestamp();
 
@@ -68,21 +66,21 @@ cron.schedule("0 */6 * * *", async () => {
     .setAuthor({ name: "⚠️ Avertissement Edits" })
     .setColor("#FF0000")
     .setDescription(
-      `**Actuellement il y a ${resultatAdminStats.editAnime} edits en cours ! \n\n Merci de vous stoper sur les edits et faire uniquements ceux necessaire tant que l'alerte est présente.**` //50
+      `**Actuellement il y a ${resultatAdminStats.editAnime} édits en cours ! \n\n Merci de vous stoper sur les édits et faire uniquements ceux necessaire tant que l'alerte est présente.**` //50
     )
     .setTimestamp();
   const embedCaFaitBeaucoupLa = new EmbedBuilder()
     .setAuthor({ name: "⚠️ Avertissement Edits" })
     .setColor("#8B0000")
     .setDescription(
-      `**Actuellement il y a ${resultatAdminStats.editAnime} edits en cours ! \n\n Nous y apprenons également le décès de <@266172334010925056> suite a un surmenage 🪦.**` //100
+      `**Actuellement il y a ${resultatAdminStats.editAnime} édits en cours ! \n\n Nous y apprenons également le décès de <@266172334010925056> suite à un surmenage 🪦.**` //100
     )
     .setTimestamp();
   const embedEditBon = new EmbedBuilder()
     .setAuthor({ name: "⚠️ Avertissement Edits" })
     .setColor("#00FF00")
     .setDescription(
-      "**Vous pouvez reprendre vos edits a un rythme normal ! \n\n Merci de votre comprhéension !**"
+      "**Vous pouvez reprendre vos édits à un rythme normal ! \n\n Merci de votre compréhension !**"
     )
     .setTimestamp();
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,20 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const { Partials,Client, Collection, GatewayIntentBits} = require('discord.js');
-const { token , appKey, appSecret, accessToken, accessSecret, twitterid, twitterChannel} = require('./config.json');
+const { Partials, Client, Collection, GatewayIntentBits, EmbedBuilder } = require('discord.js');
+const { token, appKey, appSecret, accessToken, accessSecret, twitterid, twitterChannel, channelEdit } = require('./config.json');
 const cron = require("node-cron");
+const fetch = require("node-fetch");
 const { TwitterApi } = require("twitter-api-v2");
 
-const client = new Client(    {
-	intents: [
-		GatewayIntentBits.DirectMessages,
-		GatewayIntentBits.Guilds,
-		GatewayIntentBits.GuildMessages,
-		GatewayIntentBits.MessageContent,
-		GatewayIntentBits.GuildMembers,
-	],
-	partials: [Partials.Channel],
+const client = new Client({
+  intents: [
+    GatewayIntentBits.DirectMessages,
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildMembers,
+  ],
+  partials: [Partials.Channel],
 }
 );
 
@@ -25,25 +26,97 @@ const eventFiles = fs.readdirSync(eventsPath).filter(file => file.endsWith('.js'
 
 
 for (const file of eventFiles) {
-	const filePath = path.join(eventsPath, file);
-	const event = require(filePath);
-	if (event.once) {
-		client.once(event.name, (...args) => event.execute(...args));
-	} else {
-		client.on(event.name, (...args) => event.execute(...args));
-	}
+  const filePath = path.join(eventsPath, file);
+  const event = require(filePath);
+  if (event.once) {
+    client.once(event.name, (...args) => event.execute(...args));
+  } else {
+    client.on(event.name, (...args) => event.execute(...args));
+  }
 
 }
 
 for (const file of commandFiles) {
-	const filePath = path.join(commandsPath, file);
-	const command = require(filePath);
-	client.commands.set(command.data.name, command);
-  
+  const filePath = path.join(commandsPath, file);
+  const command = require(filePath);
+  client.commands.set(command.data.name, command);
+
 }
 
 
 client.login(token);
+
+//Alerte Edits
+
+var alerte = 0; // 0 = Ok - 1 = Avertissement - 2 = Stop - 3 = Alerte
+
+cron.schedule("0 */6 * * *", async () => {
+
+  let responseAdminStats = await fetch("https://api.hyakanime.fr/admin/stats");
+  let dataAdminStats = await responseAdminStats.text();
+  var resultatAdminStats = JSON.parse(dataAdminStats);
+
+  const embedAvertissementEdit = new EmbedBuilder()
+    .setAuthor({ name: "⚠️ Avertissement Edits" })
+    .setColor("#ff6700")
+    .setDescription(
+      `**Actuellement il y a ${resultatAdminStats.editAnime} edits en cours ! \n\n Merci de vous calmez sur les edits tant que l'alerte est présente.**` //25
+    )
+    .setTimestamp();
+
+  const embedStopEdit = new EmbedBuilder()
+    .setAuthor({ name: "⚠️ Avertissement Edits" })
+    .setColor("#FF0000")
+    .setDescription(
+      `**Actuellement il y a ${resultatAdminStats.editAnime} edits en cours ! \n\n Merci de vous stoper sur les edits et faire uniquements ceux necessaire tant que l'alerte est présente.**` //50
+    )
+    .setTimestamp();
+  const embedCaFaitBeaucoupLa = new EmbedBuilder()
+    .setAuthor({ name: "⚠️ Avertissement Edits" })
+    .setColor("#8B0000")
+    .setDescription(
+      `**Actuellement il y a ${resultatAdminStats.editAnime} edits en cours ! \n\n Nous y apprenons également le décès de <@266172334010925056> suite a un surmenage 🪦.**` //100
+    )
+    .setTimestamp();
+  const embedEditBon = new EmbedBuilder()
+    .setAuthor({ name: "⚠️ Avertissement Edits" })
+    .setColor("#00FF00")
+    .setDescription(
+      "**Vous pouvez reprendre vos edits a un rythme normal ! \n\n Merci de votre comprhéension !**"
+    )
+    .setTimestamp();
+
+  const channel = client.channels.cache.get(channelEdit);
+
+  if (resultatAdminStats.editAnime >= 25) {
+    switch (true) {
+      case resultatAdminStats.editAnime >= 100:
+        if (alerte != 3) {
+          channel.send({ embeds: [embedCaFaitBeaucoupLa] });
+        }
+        alerte = 3;
+        break;
+      case resultatAdminStats.editAnime >= 50:
+        if (alerte != 2) {
+          channel.send({ embeds: [embedStopEdit] });
+        }
+        alerte = 2;
+        break;
+      case resultatAdminStats.editAnime >= 25:
+        if (alerte != 1) {
+          channel.send({ embeds: [embedAvertissementEdit] });
+        }
+        alerte = 1;
+        break;
+      default:
+    }
+  }
+
+  if (alerte >= 1 && resultatAdminStats.editAnime <= 10) {
+    channel.send({ embeds: [embedEditBon] });
+    alerte = 0;
+  }
+});
 
 //Twitter
 


### PR DESCRIPTION
Un ajout qui permet d'avoir des alertes pour savoir quand ralentir / quand y aller par rapport aux édits afin de se tenir informer de la charge de travail et éviter le plus possible de surchargé jaeger.

Il va vérifier toutes les 6 heures le nombre d'édit en cours est si il est supérieur a 25 envoyer un message sous forme d'embed afin d'avertir , il peut prendre plusieurs forme selon le nombre d'édits en cours.

Quand se nombre d'édit redescend a un nombre convenable il avertit via un autre embed que tout reprends normalement.

**/!\ Quand tu push ce pull request pense bien a verifier la config j'y ais rajouter un channelEdit, par défaut j'ai mis l'id du channel soummision support qui convient bien a ca je trouve**

Je te met un petit screen des 4 embeds qui peuvent sortir:   
![image](https://user-images.githubusercontent.com/41202006/233871724-3600ef66-db8b-41d7-9b30-31c9c7dd291a.png)
